### PR TITLE
Use python -c to get the interpreter path hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v1
     - name: set PY
-      run: echo "::set-env name=PY::$((python --version --version && which python) | sha256sum | cut -d' ' -f1)"
+      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pre-commit


### PR DESCRIPTION
The current implementation has compatibility problems due to it using commands only available on GNU Linux. Use an equivalent Python implementation for better support on Windows and macOS.