### PR TITLE
Add source and origin inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [![Build Status](https://github.com/pre-commit/action/workflows/deploy/badge.svg)](https://github.com/pre-commit/action/actions)
 
-pre-commit/action
-=================
+# pre-commit/action
+
 
 a GitHub action to run [pre-commit](https://pre-commit.com)
 
-### using this action
+## Usage
 
 To use this action, make a file `.github/workflows/pre-commit.yml`.  Here's a
 template to get started:
@@ -41,13 +41,13 @@ This does a few things:
 
 Hopefully in the future when `actions` matures the yaml can be simplified.
 
-### using this action in private repositories
+### Support for Private Repositories
 
-this action also provides an additional behaviour when used in private
-repositories.  when configured with a github token, the action will push back
+This action also provides an additional behaviour when used in private
+repositories. When configured with a GitHub token, the action will push back
 fixes to the pull request branch.
 
-here's an example configuration for that (use the template above except for the
+Here's an example configuration for that (use the template above except for the
 `pre-commit` action):
 
 ```yaml
@@ -56,10 +56,24 @@ here's an example configuration for that (use the template above except for the
         token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-note that `secrets.GITHUB_TOKEN` is automatically provisioned and will not
+Note that `secrets.GITHUB_TOKEN` is automatically provisioned and will not
 require any special configuration.
 
-while you could _technically_ configure this for a public repository (using a
+While you could _technically_ configure this for a public repository (using a
 personal access token), I can't think of a way to do this safely without
 exposing a privileged token to pull requests -- if you have any ideas, please
 leave an issue!
+
+### Commit Range
+
+In situations where you would like to check only files modified in the pull request
+you can specify the commit range using `source` for base reference sha and `origin`
+for head reference sha.
+
+```yaml
+    - uses: jirikuncar/action@release  # change to pre-commit/action@release after merging this PR
+      with:
+        source: ${{ github.event.pull_request.base.sha }}
+        origin: ${{ github.event.pull_request.head.sha }}
+```
+

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,12 @@ inputs:
   token:
     description: github token to clone / push with
     required: false
+  source:
+    description: The remote branch's commit_id when using `git push`.
+    required: false
+  origin:
+    description: The origin branch's commit_id when using `git push`.
+    required: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -2,10 +2,6 @@ const core = require('@actions/core');
 const exec = require('@actions/exec');
 const github = require('@actions/github');
 
-const ARGS = [
-    'run', '--all-files', '--show-diff-on-failure', '--color=always'
-];
-
 function addToken(url, token) {
     return url.replace(/^https:\/\//, `https://x-access-token:${token}@`)
 }
@@ -17,14 +13,33 @@ async function main() {
     });
 
     const token = core.getInput('token');
+    const source = core.getInput('source');
+    const origin = core.getInput('origin');
+
+    var args = [
+        'run', '--show-diff-on-failure', '--color=always'
+    ];
+
+    if (source) {
+        args.push('--source', source);
+    }
+    
+    if (origin) {
+        args.push('--origin', origin);
+    }
+
+    if (!!source && !!origin) {
+        args.push('--all-files');
+    }
+    
     const pr = github.context.payload.pull_request;
     const push = !!token && !!pr;
-    const ret = await exec.exec('pre-commit', ARGS, {ignoreReturnCode: push});
+    const ret = await exec.exec('pre-commit', args, {ignoreReturnCode: push});
     if (ret && push) {
         // actions do not run on pushes made by actions.
         // need to make absolute sure things are good before pushing
         // TODO: is there a better way around this limitation?
-        await exec.exec('pre-commit', ARGS);
+        await exec.exec('pre-commit', args);
 
         const diff = await exec.exec(
             'git', ['diff', '--quiet'], {ignoreReturnCode: true}


### PR DESCRIPTION
Adds support for range check using source and origin parameters:

```yaml
jobs:
  pre-commit:
    runs-on: ubuntu-latest
    if: false == startsWith(github.event.pull_request.head.ref, 'datadog-api-spec/pr/')
    steps:
    - uses: actions/checkout@v1
    - uses: actions/setup-python@v1
    - name: set PY
      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
    - uses: actions/cache@v1
      with:
        path: ~/.cache/pre-commit
        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
    - uses: jirikuncar/action@release  # change to pre-commit/action@release after merging this PR
      with:
        source: ${{ github.event.pull_request.base.sha }}
        origin: ${{ github.event.pull_request.head.sha }}
```

related to #7 
cc @asottile 