### PR TITLE
Add SPDX tags to the config template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ To use this action, make a file `.github/workflows/pre-commit.yml`.  Here's a
 template to get started:
 
 ```yaml
+# SPDX-FileCopyrightText: Copyright (c) 2019 Anthony Sottile
+#
+# SPDX-License-Identifier: MIT
+
 name: pre-commit
 
 on:


### PR DESCRIPTION
This makes it easier to copy-paste the example while carrying the right
information.