### PR TITLE
Allow action user to use custom commit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,15 @@ while you could _technically_ configure this for a public repository (using a
 personal access token), I can't think of a way to do this safely without
 exposing a privileged token to pull requests -- if you have any ideas, please
 leave an issue!
+
+
+### using this action with a custom commit message for fixes
+
+By default, fixes would be have a commit message of `pre-commit fixes`.
+A custom commit message can be added with the following configuration.
+
+```yaml
+    - uses: pre-commit/action@v2.0.0
+      with:
+        commit_message: "Custom commit message"
+```

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
   token:
     description: github token to clone / push with
     required: false
+  commit_message:
+    description: commit message when fixes are made
+    required: false
+    default: 'pre-commit fixes'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ async function main() {
     const cacheKey = `pre-commit-2-${hashString(py)}-${hashFile('.pre-commit-config.yaml')}`;
     const restored = await cache.restoreCache(cachePaths, cacheKey);
     const ret = await exec.exec('pre-commit', args, {ignoreReturnCode: push});
+    const commitMessage = core.getInput('commit_message');
     if (!restored) {
         await cache.saveCache(cachePaths, cacheKey);
     }
@@ -76,7 +77,7 @@ async function main() {
                 const branch = pr.head.ref;
                 await exec.exec('git', ['checkout', 'HEAD', '-b', branch]);
 
-                await exec.exec('git', ['commit', '-am', 'pre-commit fixes']);
+                await exec.exec('git', ['commit', '-am', commitMessage]);
                 const url = addToken(pr.head.repo.clone_url, token);
                 await exec.exec('git', ['remote', 'set-url', 'origin', url]);
                 await exec.exec('git', ['push', 'origin', 'HEAD']);


### PR DESCRIPTION
In my case, I might need to include a prefix or I might want a different commit message than the default. And my guess is that others might find that useful as well.