### PR TITLE
update docs to use latest checkout action

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,18 @@ this action also provides an additional behaviour when used in private
 repositories.  when configured with a github token, the action will push back
 fixes to the pull request branch.
 
-here's an example configuration for that (use the template above except for the
-`pre-commit` action):
+using the template above, you'll make two replacements for individual actions:
+
+first is the checkout step, which needs to use unlimited fetch depth for
+pushing
+
+```yaml
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+```
+
+next is passing the token to the pre-commit action
 
 ```yaml
     - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
I can only get this to work when setting `fetch-depth: 0`. Otherwise, I see this error:
```
push fixes
  /usr/bin/git config user.name pre-commit
  /usr/bin/git config user.email pre-commit@example.com
  /usr/bin/git checkout HEAD -b pre-commit-gha
  M	README.md
  Switched to a new branch 'pre-commit-gha'
  /usr/bin/git commit -am pre-commit fixes
  [pre-commit-gha 800dbc6] pre-commit fixes
   1 file changed, 1 insertion(+), 1 deletion(-)
  /usr/bin/git remote set-url origin ***github.com/***.git
  /usr/bin/git push origin HEAD
  To https://github.com/***.git
   ! [rejected]        HEAD -> pre-commit-gha (fetch first)
  error: failed to push some refs to 'https://github.com/***.git'
  hint: Updates were rejected because the remote contains work that you do
  hint: not have locally. This is usually caused by another repository pushing
  hint: to the same ref. You may want to first integrate the remote changes
  hint: (e.g., 'git pull ...') before pushing again.
```
