### PR TITLE
Avoid update remote of repository

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,8 +78,7 @@ async function main() {
 
                 await exec.exec('git', ['commit', '-am', 'pre-commit fixes']);
                 const url = addToken(pr.head.repo.clone_url, token);
-                await exec.exec('git', ['remote', 'set-url', 'origin', url]);
-                await exec.exec('git', ['push', 'origin', 'HEAD']);
+                await exec.exec('git', ['push', url, 'HEAD']);
             });
         }
     }


### PR DESCRIPTION
> The "remote" repository that is destination of a push operation. This parameter can be either a URL (see the section GIT URLS below) or the name of a remote (see the section REMOTES below).

https://git-scm.com/docs/git-push