### PR TITLE
CI test action after bundling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,8 @@ jobs:
     - uses: actions/setup-python@v1
     - run: pip install virtualenv
     - run: make
+    - name: self test newly built action
+      uses: ./
     - run: make push
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a step in the CI, that runs the action after newly bundeling it.
It's a kind of sanity check that the action still works as expeted and that there were no problems while bundeling.
Also, it enforces that all pre-commit check (i.e. linting) still pass on a PR, just in case someone forgot to install the hooks.