### PR TITLE
Prevent creating an already existing branch.

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ async function main() {
                 );
 
                 const branch = pr.head.ref;
-                await exec.exec('git', ['checkout', 'HEAD', '-b', branch]);
+                await exec.exec('git', ['checkout', 'HEAD', '-B', branch]);
 
                 await exec.exec('git', ['commit', '-am', 'pre-commit fixes']);
                 const url = addToken(pr.head.repo.clone_url, token);


### PR DESCRIPTION
Resolves error pushing to the current branch for private repositories

![Screen Shot 2021-04-20 at 7 00 51 PM](https://user-images.githubusercontent.com/17484350/115474133-cb5a5680-a20a-11eb-8ae9-4b34708e24e8.png)


```
    -b <branch>           create and checkout a new branch
    -B <branch>           create/reset and checkout a branch
```