### PR TITLE
docs: update to work with actions/setup-python@v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
     - uses: pre-commit/action@v3.0.0
 ```
 


### PR DESCRIPTION
The v4 update to actions/setup-python needs to specify a version.

Since the error message can be somewhat confusing, this tries to alleviate the issue as described in https://github.com/actions/setup-python/issues/421