### PR TITLE
Pin action to a commit sha

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
     shell: bash
   - run: python -m pip freeze --local
     shell: bash
-  - uses: actions/cache@v3
+  - uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # actions/cache@v3.2.6
     with:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
Some projects have security requirement that enforce pinning of actions to commit sha hashes, to protect the CI of the project from supply-chain attacks compromising the runner. In such case, only a list of allowed actions would be able to run.

To allow running 'pre-commit/action' (even when pinned to a commit sha), currently requires also allowing running `actions/cache@v3` which isn't pinned to a commit sha (and poses a supply-chain risk).

This PR pins the action to the commit sha matching the `v3` ref (currently `v3.2.6` tag) - https://github.com/actions/cache/commit/69d9d449aced6a2ede0bc19182fadc3a0a42d2b0