### PR TITLE
Bump version of setup to get rid of deprecation and avoid failure at the end of May.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
     - uses: pre-commit/action@v3.0.0
 ```
 


### PR DESCRIPTION
From the incluided commit:

> Bump up setup-python to v4, because v3 triggers this warning:
> 
> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
> 
> Github states that
> 
> > ... and plan to fully disable them on 31st May 2023.