### PR TITLE
Always save checked out hooks in GitHub Actions cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,6 @@ runs:
     with:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      save-always: true
   - run: pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash


### PR DESCRIPTION
As of actions/cache@v4 it's now possible to always save the cache, even if a previous step fails. This would be useful for avoiding recloning hooks when `pre-commit run` fails and the cache is empty.