### PR TITLE
Modified pipeline to use explicit pre-commit version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,20 @@ inputs:
     description: options to pass to pre-commit run
     required: false
     default: '--all-files'
+  version:
+    description: pre-commit version
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
-  - run: python -m pip install pre-commit
+  - id: Install pre-commit (latest)
+    if: ${{ inputs.version == '' }}
+    run: python -m pip install pre-commit
+    shell: bash
+  - id: Install pre-commit ${{ inputs.version }}
+    if: ${{ inputs.version != '' }}
+    run: python -m pip install pre-commit==${{ inputs.version }}
     shell: bash
   - run: python -m pip freeze --local
     shell: bash


### PR DESCRIPTION
This PR modifies the pre-commit pipeline to inject a version argument, allowing users to configure exactly which version of pre-commit they're installing. This is important because v4.0.0 can break pipelines.