### PR TITLE
feat: allow restoring cache from older versions of .pre-commit-config.yaml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,10 @@ runs:
     with:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      restore-keys: |
+        pre-commit-3|${{ env.pythonLocation }}|
+        pre-commit-3|
   - run: pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
+    shell: bash
+  - run: pre-commit gc
     shell: bash


### PR DESCRIPTION
# What

Allow restoring the cache from an older version of the config file

This means that when adding a new hook to the config, we still retrieve the previously cached repositories. Any newly added repos will be added to the cache with the new config's hash.

If the change is to update hook versions, we will still restore the previously cached versions and then pull down the new versions. The trailing `pre-commit gc` will remove the old versions before pushing the new version of the cache up.

This reduces the time spent 'Initializing environment' when a minor change is made to the configuration, and reduces the impact surface for networking flubs during pre-commit runs, because we should overall be doing less pulling.
