### PR TITLE
Pin `actions/cache` to a full-length commit SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
     shell: bash
   - run: python -m pip freeze --local
     shell: bash
-  - uses: actions/cache@v4
+  - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
     with:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
GitHub repositories can enforce that all workflow actions are pinned to a full-length commit SHA. When the setting is enabled, GitHub will fail jobs using actions that aren't pinned, including actions used by other actions.
<img width="431" height="36" alt="image" src="https://github.com/user-attachments/assets/b13e6a17-eaa3-46c7-89af-4683dd30cc29" />

Can we please pin `actions/cache` to a SHA to allow `pre-commit/action` users enable the setting?