### PR TITLE
Pin actions/cache to commit SHA for better security

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
     shell: bash
   - run: python -m pip freeze --local
     shell: bash
-  - uses: actions/cache@v4
+  - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
     with:
       path: ~/.cache/pre-commit
       key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
ESPHome uses this action in CI and when we turned on the security setting to require SHA versions only, this one stood out.